### PR TITLE
Do not escape translations because we use React

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -89,9 +89,9 @@ describe('i18n', () => {
           }).toThrowError()
         })
 
-        it('interpolates and escapes', () => {
+        it('interpolates and do not escapes', () => {
           expect(i18n.t('hello', { name: '<b>coca-cola</b>' })).toBe(
-            'hola &lt;b&gt;coca-cola&lt;/b&gt;'
+            'hola <b>coca-cola</b>'
           )
         })
       })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factorial-i18n",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Factorial i18n library",
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ export default class I18n {
           `Translation "${path}" has a missing interpolation value "${subst}"`
         )
       }
-      return _.escape(String(opts[subst]))
+      return String(opts[subst])
     })
   }
 


### PR DESCRIPTION
### What?
Translations should not be escaped if you're using React
![image](https://user-images.githubusercontent.com/49499/28316684-15d80d0a-6bc4-11e7-8bb7-ca6a0b76db8b.png)
