### PR TITLE
Differentiate exceptions with missing keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "jest": { "preset": "ts-jest" },
   "dependencies": {
-    "lodash.at": "4.6.0",
+    "lodash": "^4.17.15",
     "plurals-cldr": "1.0.3"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-const at = require('lodash.at')
+const at = require('lodash/at')
+const isEmpty = require('lodash/isEmpty')
 import plural from 'plurals-cldr'
 
 type TranslationValue = string | TranslationObject;
@@ -36,6 +37,10 @@ export default class I18n {
    * Retrieves a key from the translations object.
    */
   getKey (path: string): TranslationObject | string {
+    if (isEmpty(this.translations)) {
+      throw new Error('Translations have not been loaded')
+    }
+
     return at(this.translations[this.locale], path)[0]
   }
 
@@ -51,7 +56,7 @@ export default class I18n {
   t (path: string, opts?: { [key: string]: any }): string {
     const value = this.getKey(path)
     if (typeof value !== 'string') {
-      throw new Error(`Key "${path}"is not a leaf`)
+      throw new Error(`Key "${path}" is not a leaf`)
     }
     const MATCH = /%\{([^}]+)\}/g
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2422,10 +2422,6 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash.at@4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.at/-/lodash.at-4.6.0.tgz#93cdce664f0a1994ea33dd7cd40e23afd11b0ff8"
-
 lodash.chunk@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.chunk/-/lodash.chunk-4.2.0.tgz#66e5ce1f76ed27b4303d8c6512e8d1216e8106bc"
@@ -2441,6 +2437,7 @@ lodash.unescape@4.0.1:
 lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
I keep seeing many exceptions in a row when the locale file was not loaded. This is giving us a false positive for missing keys.

Right now we are throwing the same exception when we don't find an i18n key or when the translations were not loaded properly.

Adding a new one for this case.