### PR TITLE
Remove `global` from `Intl` call

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export default class I18n {
    * Leverages Intl.NumberFormat for currency formatting
    */
   formatNumber (num: number, style?: string, currency?: string): string {
-    return new global.Intl.NumberFormat(
+    return new Intl.NumberFormat(
       this.locale,
       { style, currency }
     ).format(num)


### PR DESCRIPTION
Browsers don't offer a `global` object natively anymore. To have this working it must be explicitly configured. Instead, `Intl` is usually available on `globalThis`, so it can be simply accessed in the toplevel. We remove the `global` to allow this to happen.