### PR TITLE
Improve error message for I18n.tp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export default class I18n {
     const num = opts.count
 
     if (typeof num !== 'number') {
-      throw new Error('You must have a `count` property')
+      throw new Error('You must have a `count` property and it cannot be null')
     }
 
     const form = plural(this.locale, num)

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export default class I18n {
     const num = opts.count
 
     if (typeof num !== 'number') {
-      throw new Error('You must have a `count` property and it cannot be null')
+      throw new Error('You must have a `count` property and it must be a non-null number')
     }
 
     const form = plural(this.locale, num)


### PR DESCRIPTION
We've been getting errors like this one:

```
You must have a `count` property
```

But the code is this:

```js
let collLength = collection?.length
i18n.tp('foo.bar', {
    count: collLength,
  })
```

The error is a bit misleading, because the property `count` **is defined**, but the problem is that it's null. 

This commit fixes the error message so it's a bit more clear about what might be happening.