### PR TITLE
adding zero

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -23,6 +23,7 @@ const mockedTranslations = {
   es: {
     hello: 'hola %{name}',
     beers: {
+      zero: 'sin cervezas!',
       one: '%{count} cerveza',
       other: '%{count} cervezas'
     },
@@ -151,7 +152,7 @@ describe('i18n', () => {
       })
 
       it('uses pluralizations correctly otherwise', () => {
-        expect(i18n.tp('beers', { count: 0 })).toBe('0 cervezas')
+        expect(i18n.tp('beers', { count: 0 })).toBe('sin cervezas!')
         expect(i18n.tp('beers', { count: 1 })).toBe('1 cerveza')
         expect(i18n.tp('beers', { count: 2 })).toBe('2 cervezas')
       })

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "jest": { "preset": "ts-jest" },
   "dependencies": {
     "lodash": "^4.17.15",
-    "plurals-cldr": "1.0.3"
+    "plurals-cldr": "2.0.1"
   },
   "devDependencies": {
     "@types/jest": "24.0.13",

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,10 @@ export default class I18n {
     }
 
     const form = plural(this.locale, num)
-    const pluralPath = `${path}.${form}`
+    let pluralPath = `${path}.${form}`
+    if (num === 0 && this.getKey(`${path}.zero`) !== undefined) {
+      pluralPath = `${path}.zero`
+    }
 
     return this.t(pluralPath, opts)
   }


### PR DESCRIPTION
## 🚪 Why?

To can have a special literal in case the count is zero

## 🔑 What?

Inspect for the zero key as plural library seems not having this
