### PR TITLE
Add support for fallback language and manage not found uncommon plural forms

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -50,6 +50,11 @@ const mockedTranslations = {
   },
   ru: {
     colas: {},
+    books: {
+      one: '%{count} книга',
+      few: '%{count} книги', 
+      many: '%{count} книг',
+    },
     beers: {
       one: '%{count} пива',
       other: '%{count} пива'
@@ -115,6 +120,13 @@ describe('i18n', () => {
 
       it('falls back to english if the path is not found', () => {
         expect(i18n.tp('colas', { count: 0 })).toBe('0 colas')
+      })
+
+      it('gets the correct plural form', () => {
+        expect(i18n.tp('books', { count: 0 })).toBe('0 книг')
+        expect(i18n.tp('books', { count: 1 })).toBe('1 книга')
+        expect(i18n.tp('books', { count: 2 })).toBe('2 книги')
+        expect(i18n.tp('books', { count: 5 })).toBe('5 книг')
       })
     })
   })

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -8,6 +8,10 @@ const mockedTranslations = {
       one: '%{count} beer',
       other: '%{count} beers'
     },
+    colas: {
+      one: '%{count} cola',
+      other: '%{count} colas',
+    },
     role: {
       admin: 'admin',
       basic: 'basic'
@@ -42,6 +46,13 @@ const mockedTranslations = {
     beers: {
       one: '%{count} bière',
       other: '%{count} bières'
+    }
+  },
+  ru: {
+    colas: {},
+    beers: {
+      one: '%{count} пива',
+      other: '%{count} пива'
     }
   }
 }
@@ -87,6 +98,23 @@ describe('i18n', () => {
             'hola <b>coca-cola</b>'
           )
         })
+      })
+    })
+  })
+
+  describe('with russian locale', () => {
+    beforeEach(() => {
+      i18n.setLocale('ru')
+      i18n.setLocaleFallback('en')
+    })
+
+    describe('when we want to express complex forms of pluralization', () => {
+      it('falls back to other if many or few is not found', () => {
+        expect(i18n.tp('beers', { count: 0 })).toBe('0 пива')
+      })
+
+      it('falls back to english if the path is not found', () => {
+        expect(i18n.tp('colas', { count: 0 })).toBe('0 colas')
       })
     })
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,102 +1,119 @@
-const at = require('lodash/at')
-const isEmpty = require('lodash/isEmpty')
-import plural from 'plurals-cldr'
+const at = require('lodash/at');
+const isEmpty = require('lodash/isEmpty');
+import plural from 'plurals-cldr';
 
 type TranslationValue = string | TranslationObject;
 interface TranslationObject {
-  [x: string]: TranslationValue;
+    [x: string]: TranslationValue;
 }
 
 export default class I18n {
-  translations: TranslationObject
-  locale: string
+    translations: TranslationObject;
+    locale: string;
+    localeFallback: string;
 
-  constructor () {
-    this.translations = {}
-  }
-
-  setTranslations (translations: TranslationObject): void {
-    this.translations = translations
-  }
-
-  setLocale (locale: string): void {
-    this.locale = locale
-  }
-
-  /**
-   * Leverages Intl.NumberFormat for currency formatting
-   */
-  formatNumber (num: number, style?: string, currency?: string): string {
-    return new Intl.NumberFormat(
-      this.locale,
-      { style, currency }
-    ).format(num)
-  }
-
-  /**
-   * Retrieves a key from the translations object.
-   */
-  getKey (path: string): TranslationObject | string {
-    if (isEmpty(this.translations)) {
-      throw new Error('Translations have not been loaded')
+    constructor() {
+        this.translations = {};
     }
 
-    return at(this.translations[this.locale], path)[0]
-  }
-
-  /**
-   * Translate a key
-   * Interpolate values with %{name}
-   *
-   * Examples:
-   *
-   * t('foo.bar') => 'Bar'
-   * t('zemba.fleiba', {num: 3 }) => 'Zemba 3 Fleiba!'
-   */
-  t (path: string, opts?: { [key: string]: any }): string {
-    const value = this.getKey(path)
-    if (typeof value !== 'string') {
-      throw new Error(`Key "${path}" is not a leaf`)
-    }
-    const MATCH = /%\{([^}]+)\}/g
-
-    return value.replace(MATCH, (match, subst) => {
-      if (!opts) return ''
-      return String(opts[subst])
-    })
-  }
-
-  /**
-   * Translate singular o plural copies
-   * Options must contain `count`
-   *
-   * Examples:
-   *
-   * tp('beer', { count: 3 }) => '3 beers'
-   */
-  tp (path: string, opts: { [key: string]: any }): string {
-    const num = opts.count
-
-    if (typeof num !== 'number') {
-      throw new Error('You must have a `count` property and it must be a non-null number')
+    setTranslations(translations: TranslationObject): void {
+        this.translations = translations;
     }
 
-    const form = plural(this.locale, num)
-    const pluralPath = `${path}.${form}`
+    setLocale(locale: string): void {
+        this.locale = locale;
+    }
 
-    return this.t(pluralPath, opts)
-  }
+    setLocaleFallback(locale: string): void {
+        this.localeFallback = locale;
+    }
 
-  /**
-   * Conditional copies, made easy.
-   * Provide a path and then options, like classNames
-   *
-   * Example:
-   *
-   *   tx('fleiba.zemba', user.get('role'))
-   */
-  tx (path: string, variable: string, opts?: { [key: string]: any }): string {
-    const newPath = `${path}.${variable}`
-    return this.t(newPath, opts)
-  }
+    /**
+     * Leverages Intl.NumberFormat for currency formatting
+     */
+    formatNumber(num: number, style?: string, currency?: string): string {
+        return new Intl.NumberFormat(this.locale, { style, currency }).format(
+            num
+        );
+    }
+
+    /**
+     * Retrieves a key from the translations object.
+     */
+    getKey(path: string): TranslationObject | string {
+        if (isEmpty(this.translations)) {
+            throw new Error('Translations have not been loaded');
+        }
+
+        const result =
+            at(this.translations[this.locale], path)[0] ||
+            at(this.translations[this.localeFallback], path)[0];
+
+        return result;
+    }
+
+    /**
+     * Translate a key
+     * Interpolate values with %{name}
+     *
+     * Examples:
+     *
+     * t('foo.bar') => 'Bar'
+     * t('zemba.fleiba', {num: 3 }) => 'Zemba 3 Fleiba!'
+     */
+    t(path: string, opts?: { [key: string]: any }): string {
+        const value = this.getKey(path);
+        if (typeof value !== 'string') {
+            throw new Error(`Key "${path}" is not a leaf`);
+        }
+        const MATCH = /%\{([^}]+)\}/g;
+
+        return value.replace(MATCH, (match, subst) => {
+            if (!opts) return '';
+            return String(opts[subst]);
+        });
+    }
+
+    /**
+     * Translate singular o plural copies
+     * Options must contain `count`
+     *
+     * Examples:
+     *
+     * tp('beer', { count: 3 }) => '3 beers'
+     */
+    tp(path: string, opts: { [key: string]: any }): string {
+        const num = opts.count;
+
+        if (typeof num !== 'number') {
+            throw new Error(
+                'You must have a `count` property and it must be a non-null number'
+            );
+        }
+
+        let form = plural(this.locale, num);
+        let pluralPath = `${path}.${form}`;
+
+        try {
+            return this.t(pluralPath, opts);
+        } catch (e) {
+            form = plural(this.localeFallback, num);
+            pluralPath = `${path}.${form}`;
+            console.log('pluralPath', pluralPath);
+            return this.t(pluralPath, opts);
+        }
+    }
+
+    /**
+     * Conditional copies, made easy.
+     * Provide a path and then options, like classNames
+     *
+     * Example:
+     *
+     *   tx('fleiba.zemba', user.get('role'))
+     */
+    tx(path: string, variable: string, opts?: { [key: string]: any }): string {
+        const newPath = `${path}.${variable}`;
+        return this.t(newPath, opts);
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,119 +1,115 @@
-const at = require('lodash/at');
-const isEmpty = require('lodash/isEmpty');
-import plural from 'plurals-cldr';
+const at = require('lodash/at')
+const isEmpty = require('lodash/isEmpty')
+import plural from 'plurals-cldr'
 
 type TranslationValue = string | TranslationObject;
 interface TranslationObject {
-    [x: string]: TranslationValue;
+  [x: string]: TranslationValue;
 }
 
 export default class I18n {
-    translations: TranslationObject;
-    locale: string;
-    localeFallback: string;
+  translations: TranslationObject
+  locale: string
+  localeFallback: string
 
-    constructor() {
-        this.translations = {};
+  constructor () {
+    this.translations = {}
+  }
+
+  setTranslations (translations: TranslationObject): void {
+    this.translations = translations
+  }
+
+  setLocale (locale: string): void {
+    this.locale = locale
+  }
+ 
+  setLocaleFallback(locale: string): void {
+    this.localeFallback = locale;
+  }
+
+  /**
+   * Leverages Intl.NumberFormat for currency formatting
+   */
+  formatNumber (num: number, style?: string, currency?: string): string {
+    return new Intl.NumberFormat(
+      this.locale,
+      { style, currency }
+    ).format(num)
+  }
+
+  /**
+   * Retrieves a key from the translations object.
+   */
+  getKey (path: string): TranslationObject | string {
+    if (isEmpty(this.translations)) {
+      throw new Error('Translations have not been loaded')
+    }
+   
+    const result = at(this.translations[this.locale], path)[0] || at(this.translations[this.localeFallback], path)[0]
+
+    return result
+  }
+
+  /**
+   * Translate a key
+   * Interpolate values with %{name}
+   *
+   * Examples:
+   *
+   * t('foo.bar') => 'Bar'
+   * t('zemba.fleiba', {num: 3 }) => 'Zemba 3 Fleiba!'
+   */
+  t (path: string, opts?: { [key: string]: any }): string {
+    const value = this.getKey(path)
+    if (typeof value !== 'string') {
+      throw new Error(`Key "${path}" is not a leaf`)
+    }
+    const MATCH = /%\{([^}]+)\}/g
+
+    return value.replace(MATCH, (match, subst) => {
+      if (!opts) return ''
+      return String(opts[subst])
+    })
+  }
+
+  /**
+   * Translate singular o plural copies
+   * Options must contain `count`
+   *
+   * Examples:
+   *
+   * tp('beer', { count: 3 }) => '3 beers'
+   */
+  tp (path: string, opts: { [key: string]: any }): string {
+    const num = opts.count
+
+    if (typeof num !== 'number') {
+      throw new Error('You must have a `count` property and it must be a non-null number')
     }
 
-    setTranslations(translations: TranslationObject): void {
-        this.translations = translations;
+    let form = plural(this.locale, num)
+    let pluralPath = `${path}.${form}`
+
+    try {
+      return this.t(pluralPath, opts)
+    } catch (e) {
+      form = plural(this.localeFallback, num)
+      pluralPath = `${path}.${form}`
+      return this.t(pluralPath, opts)
     }
+  }
 
-    setLocale(locale: string): void {
-        this.locale = locale;
-    }
-
-    setLocaleFallback(locale: string): void {
-        this.localeFallback = locale;
-    }
-
-    /**
-     * Leverages Intl.NumberFormat for currency formatting
-     */
-    formatNumber(num: number, style?: string, currency?: string): string {
-        return new Intl.NumberFormat(this.locale, { style, currency }).format(
-            num
-        );
-    }
-
-    /**
-     * Retrieves a key from the translations object.
-     */
-    getKey(path: string): TranslationObject | string {
-        if (isEmpty(this.translations)) {
-            throw new Error('Translations have not been loaded');
-        }
-
-        const result =
-            at(this.translations[this.locale], path)[0] ||
-            at(this.translations[this.localeFallback], path)[0];
-
-        return result;
-    }
-
-    /**
-     * Translate a key
-     * Interpolate values with %{name}
-     *
-     * Examples:
-     *
-     * t('foo.bar') => 'Bar'
-     * t('zemba.fleiba', {num: 3 }) => 'Zemba 3 Fleiba!'
-     */
-    t(path: string, opts?: { [key: string]: any }): string {
-        const value = this.getKey(path);
-        if (typeof value !== 'string') {
-            throw new Error(`Key "${path}" is not a leaf`);
-        }
-        const MATCH = /%\{([^}]+)\}/g;
-
-        return value.replace(MATCH, (match, subst) => {
-            if (!opts) return '';
-            return String(opts[subst]);
-        });
-    }
-
-    /**
-     * Translate singular o plural copies
-     * Options must contain `count`
-     *
-     * Examples:
-     *
-     * tp('beer', { count: 3 }) => '3 beers'
-     */
-    tp(path: string, opts: { [key: string]: any }): string {
-        const num = opts.count;
-
-        if (typeof num !== 'number') {
-            throw new Error(
-                'You must have a `count` property and it must be a non-null number'
-            );
-        }
-
-        let form = plural(this.locale, num);
-        let pluralPath = `${path}.${form}`;
-
-        try {
-            return this.t(pluralPath, opts);
-        } catch (e) {
-            form = plural(this.localeFallback, num);
-            pluralPath = `${path}.${form}`;
-            console.log('pluralPath', pluralPath);
-            return this.t(pluralPath, opts);
-        }
-    }
-
-    /**
-     * Conditional copies, made easy.
-     * Provide a path and then options, like classNames
-     *
-     * Example:
-     *
-     *   tx('fleiba.zemba', user.get('role'))
-     */
-    tx(path: string, variable: string, opts?: { [key: string]: any }): string {
-        const newPath = `${path}.${variable}`;
-        return this.t(newPath, opts);
-    }
+  /**
+   * Conditional copies, made easy.
+   * Provide a path and then options, like classNames
+   *
+   * Example:
+   *
+   *   tx('fleiba.zemba', user.get('role'))
+   */
+  tx (path: string, variable: string, opts?: { [key: string]: any }): string {
+    const newPath = `${path}.${variable}`
+    return this.t(newPath, opts)
+  }
 }


### PR DESCRIPTION
## 🔑 What?

Add support for fallback language and manage not found uncommon plural forms.

## 🚪 Why?

We need to support two common use cases in our library, this is because when adding a new language it's pretty common to not have all leafs defined in our new language source file.

The first case is allowing to set a fallback language, meaning that when a translation is not found in your primary language that is set it will try to return the one that should be specified in the fallback language.

Second use case that we're targeting with this is to fallback to "other" plural form when "many" or "few" is the one we want but it's not defined.
